### PR TITLE
Folder based changes

### DIFF
--- a/MapBuddy/Action/EnemyDupe.cs
+++ b/MapBuddy/Action/EnemyDupe.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 using SoulsFormats;
 using SoulsFormats.KF4;
 using static SoulsFormats.MSB.Shape.Composite;
@@ -61,12 +62,12 @@ namespace MapBuddy.Action
         {
             List<MSBE.Part.Enemy> new_enemies = new List<MSBE.Part.Enemy>();
 
-            string ResourceFolder = System.AppDomain.CurrentDomain.BaseDirectory + "\\Resources\\";
+            string ResourceFolder = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "Resources");
 
-            string boss_list = File.ReadAllText(ResourceFolder + "enemy_boss.txt");
-            string passive_list = File.ReadAllText(ResourceFolder + "enemy_passive.txt");
-            string player_list = File.ReadAllText(ResourceFolder + "enemy_player.txt");
-            string script_list = File.ReadAllText(ResourceFolder + "enemy_script.txt");
+            string boss_list = File.ReadAllText(Path.Combine(ResourceFolder, "enemy_boss.txt"));
+            string passive_list = File.ReadAllText(Path.Combine(ResourceFolder + "enemy_passive.txt"));
+            string player_list = File.ReadAllText(Path.Combine(ResourceFolder + "enemy_player.txt"));
+            string script_list = File.ReadAllText(Path.Combine(ResourceFolder + "enemy_script.txt"));
 
             string[] boss_exclusion = boss_list.Split(";");
             string[] passive_exclusion = passive_list.Split(";");

--- a/MapBuddy/EventInfo/InfoGenerator.cs
+++ b/MapBuddy/EventInfo/InfoGenerator.cs
@@ -18,7 +18,7 @@ namespace MapBuddy.EventInfo
 
         public InfoGenerator(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Event\\Generator\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Event", "Generator");
 
             header = $"EventID;" +
                     $"PartName;" +

--- a/MapBuddy/EventInfo/InfoGenerator.cs
+++ b/MapBuddy/EventInfo/InfoGenerator.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.EventInfo
 {

--- a/MapBuddy/EventInfo/InfoMount.cs
+++ b/MapBuddy/EventInfo/InfoMount.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.EventInfo
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.EventInfo
 
         public InfoMount(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Event\\Mount\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Event", "Mount");
 
             header = $"EventID;" +
                     $"PartName;" +

--- a/MapBuddy/EventInfo/InfoNavmesh.cs
+++ b/MapBuddy/EventInfo/InfoNavmesh.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.EventInfo
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.EventInfo
 
         public InfoNavmesh(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Event\\Navmesh\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Event", "Navmesh");
 
             header = $"EventID;" +
                     $"PartName;" +

--- a/MapBuddy/EventInfo/InfoObjAct.cs
+++ b/MapBuddy/EventInfo/InfoObjAct.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.EventInfo
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.EventInfo
 
         public InfoObjAct(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Event\\ObjAct\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Event", "ObjAct");
 
             header = $"EventID;" +
                     $"PartName;" +

--- a/MapBuddy/EventInfo/InfoOther_event.cs
+++ b/MapBuddy/EventInfo/InfoOther_event.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.EventInfo
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.EventInfo
 
         public InfoOther_event(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Event\\Other\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Event", "Other");
 
             header = $"EventID;" +
                     $"PartName;" +

--- a/MapBuddy/EventInfo/InfoPatrolInfo.cs
+++ b/MapBuddy/EventInfo/InfoPatrolInfo.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.EventInfo
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.EventInfo
 
         public InfoPatrolInfo(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Event\\PatrolInfo\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Event", "PatrolInfo");
 
             header = $"EventID;" +
                     $"PartName;" +

--- a/MapBuddy/EventInfo/InfoPlatoonInfo.cs
+++ b/MapBuddy/EventInfo/InfoPlatoonInfo.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.EventInfo
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.EventInfo
 
         public InfoPlatoonInfo(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Event\\PlatoonInfo\\";
+            output_dir = Path.Combine(logger.GetLogDir() , "Event", "PlatoonInfo");
 
             header = $"EventID;" +
                     $"PartName;" +

--- a/MapBuddy/EventInfo/InfoPseudoMultiplayer.cs
+++ b/MapBuddy/EventInfo/InfoPseudoMultiplayer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.EventInfo
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.EventInfo
 
         public InfoPseudoMultiplayer(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Event\\PsuedoMultiplayer\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Event", "PsuedoMultiplayer");
 
             header = $"EventID;" +
                     $"PartName;" +

--- a/MapBuddy/EventInfo/InfoRetryPoint.cs
+++ b/MapBuddy/EventInfo/InfoRetryPoint.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.EventInfo
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.EventInfo
 
         public InfoRetryPoint(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Event\\RetryPoint\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Event", "RetryPoint");
 
             header = $"EventID;" +
                     $"PartName;" +
@@ -50,7 +51,7 @@ namespace MapBuddy.EventInfo
             {
                 header = $"MapID;" + header; // Add MapID column for combined file
 
-                File.WriteAllText(output_dir + $"{combined_file_name}.{file_format}", header);
+                File.WriteAllText(Path.Combine(output_dir, $"{combined_file_name}.{file_format}"), header);
             }
 
             foreach (KeyValuePair<string, string> entry in mapDict)
@@ -77,7 +78,7 @@ namespace MapBuddy.EventInfo
             // By Map: write header here
             if (outputByMap)
             {
-                File.WriteAllText(output_dir + $"{map_name}.{file_format}", header);
+                File.WriteAllText(Path.Combine(output_dir, $"{map_name}.{file_format}"), header);
             }
 
             foreach (MSBE.Event.RetryPoint entry in msb.Events.RetryPoints)
@@ -116,12 +117,12 @@ namespace MapBuddy.EventInfo
             // By Map
             if (outputByMap)
             {
-                File.AppendAllText(output_dir + $"{map_name}.{file_format}", text);
+                File.AppendAllText(Path.Combine(output_dir, $"{map_name}.{file_format}"), text);
             }
             // Combined
             else
             {
-                File.AppendAllText(output_dir + $"{combined_file_name}.{file_format}", text);
+                File.AppendAllText(Path.Combine(output_dir, $"{combined_file_name}.{file_format}"), text);
             }
         }
     }

--- a/MapBuddy/EventInfo/InfoSignPool.cs
+++ b/MapBuddy/EventInfo/InfoSignPool.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.EventInfo
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.EventInfo
 
         public InfoSignPool(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Event\\SignPool\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Event", "SignPool");
 
             header = $"EventID;" +
                     $"PartName;" +

--- a/MapBuddy/EventInfo/InfoTreasure.cs
+++ b/MapBuddy/EventInfo/InfoTreasure.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.EventInfo
 {
@@ -20,7 +21,7 @@ namespace MapBuddy.EventInfo
 
         public InfoTreasure(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Event\\Treasure\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Event", "Treasure");
 
             header = $"EventID;" +
                     $"PartName;" +

--- a/MapBuddy/Logger.cs
+++ b/MapBuddy/Logger.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy
 {
@@ -19,14 +20,14 @@ namespace MapBuddy
         {
             string logDir = GetLogDir();
 
-            bool exists = System.IO.Directory.Exists(logDir);
+            bool exists = Directory.Exists(logDir);
 
             if (!exists)
             {
-                System.IO.Directory.CreateDirectory(logDir);
+                Directory.CreateDirectory(logDir);
             }
 
-            File.AppendAllText($"{logDir}log.txt", log);
+            File.AppendAllText(Path.Combine(logDir, "log.txt"), log);
 
             log = "";
         }
@@ -38,7 +39,7 @@ namespace MapBuddy
 
         public string GetLogDir()
         {
-            return System.AppDomain.CurrentDomain.BaseDirectory + "\\Log\\";
+            return Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "Log");
         }
     }
 }

--- a/MapBuddy/MainWindow.cs
+++ b/MapBuddy/MainWindow.cs
@@ -12,15 +12,34 @@ namespace MapBuddy
 {
     public partial class MainWindow : Form
     {
-        string mod_folder = null;
-        string log_dir = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "Log");
+        static string baseDir = System.AppDomain.CurrentDomain.BaseDirectory;
+        string settings_file = Path.Combine(baseDir, "MapBuddySettings.txt");
+        string log_dir = Path.Combine(baseDir, "Log");
+
+        string mod_folder
+        {
+            get
+            {
+                if (_mod_folder == null)
+                {
+                    if (File.Exists(settings_file))
+                        _mod_folder = File.ReadAllText(settings_file);
+                    else
+                        _mod_folder = String.Empty;
+                }
+                return _mod_folder;
+            }
+            set 
+            { 
+                _mod_folder = value;
+                File.WriteAllText(settings_file, _mod_folder);
+            }
+        }
+        string? _mod_folder = null;
 
         public MainWindow()
         {
             InitializeComponent();
-
-            mod_folder = "";
-            //mod_folder = "C:\\Users\\Xylozi\\Documents\\C# Projects\\MapBuddy\\MapBuddy\\bin\\Debug\\net7.0-windows\\example_mod";
 
             textbox_mod_folder.Text = mod_folder;
 
@@ -54,6 +73,9 @@ namespace MapBuddy
         
         private void UpdateMapSelection(string path)
         {
+            if (String.IsNullOrEmpty(path))
+                return;
+
             List<string> maps = Directory.GetFileSystemEntries(Path.Combine(path, "map", "mapstudio"), @"*.msb.dcx").ToList();
 
             cb_map_select.Items.Clear();

--- a/MapBuddy/MainWindow.cs
+++ b/MapBuddy/MainWindow.cs
@@ -13,25 +13,25 @@ namespace MapBuddy
     public partial class MainWindow : Form
     {
         string mod_folder = null;
-        string log_dir = System.AppDomain.CurrentDomain.BaseDirectory + "\\Log\\";
+        string log_dir = Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "Log");
 
         public MainWindow()
         {
             InitializeComponent();
 
-            //mod_folder = "";
-            mod_folder = "C:\\Users\\Xylozi\\Documents\\C# Projects\\MapBuddy\\MapBuddy\\bin\\Debug\\net7.0-windows\\example_mod";
+            mod_folder = "";
+            //mod_folder = "C:\\Users\\Xylozi\\Documents\\C# Projects\\MapBuddy\\MapBuddy\\bin\\Debug\\net7.0-windows\\example_mod";
 
             textbox_mod_folder.Text = mod_folder;
 
-            bool exists = System.IO.Directory.Exists(log_dir);
+            bool exists = Directory.Exists(log_dir);
 
             if (!exists)
             {
-                System.IO.Directory.CreateDirectory(log_dir);
+                Directory.CreateDirectory(log_dir);
             }
 
-            File.WriteAllText(log_dir + $"log.txt", "");
+            File.WriteAllText(Path.Combine(log_dir, "log.txt"), "");
 
             // Defaults
             c_entityid_enemy.Checked = true;
@@ -51,9 +51,10 @@ namespace MapBuddy
 
             UpdateMapSelection(mod_folder);
         }
+        
         private void UpdateMapSelection(string path)
         {
-            List<string> maps = Directory.GetFileSystemEntries(path + "\\map\\mapstudio", @"*.msb.dcx").ToList();
+            List<string> maps = Directory.GetFileSystemEntries(Path.Combine(path, "map", "mapstudio"), @"*.msb.dcx").ToList();
 
             cb_map_select.Items.Clear();
 

--- a/MapBuddy/PartInfo/InfoAsset.cs
+++ b/MapBuddy/PartInfo/InfoAsset.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.Info
 {
@@ -19,7 +20,7 @@ namespace MapBuddy.Info
 
         public InfoAsset(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Part\\Asset\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Part", "Asset");
 
             header = $"Name;" +
                     $"ModelName;" +

--- a/MapBuddy/PartInfo/InfoCollision.cs
+++ b/MapBuddy/PartInfo/InfoCollision.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.Info
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.Info
 
         public InfoCollision(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Part\\Collision\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Part", "Collision");
 
             header = $"Name;" +
                     $"ModelName;" +

--- a/MapBuddy/PartInfo/InfoConnectCollision.cs
+++ b/MapBuddy/PartInfo/InfoConnectCollision.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.Info
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.Info
 
         public InfoConnectCollision(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Part\\ConnectCollision\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Part", "ConnectCollision");
 
             header = $"Name;" +
                     $"ModelName;" +

--- a/MapBuddy/PartInfo/InfoDummyAsset.cs
+++ b/MapBuddy/PartInfo/InfoDummyAsset.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.Info
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.Info
 
         public InfoDummyAsset(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Part\\DummyAsset\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Part", "DummyAsset");
 
             header = $"Name;" +
                     $"ModelName;" +

--- a/MapBuddy/PartInfo/InfoDummyEnemy.cs
+++ b/MapBuddy/PartInfo/InfoDummyEnemy.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.Info
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.Info
 
         public InfoDummyEnemy(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Part\\DummyEnemy\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Part", "DummyEnemy");
 
             header = $"Name;" +
                     $"ModelName;" +

--- a/MapBuddy/PartInfo/InfoEnemy.cs
+++ b/MapBuddy/PartInfo/InfoEnemy.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.Info
 {
@@ -19,7 +20,7 @@ namespace MapBuddy.Info
 
         public InfoEnemy(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Part\\Enemy\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Part", "Enemy");
 
             header = $"Name;" +
                     $"ModelName;" +

--- a/MapBuddy/PartInfo/InfoMapPiece.cs
+++ b/MapBuddy/PartInfo/InfoMapPiece.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.Info
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.Info
 
         public InfoMapPiece(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Part\\MapPiece\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Part", "MapPiece");
 
             header = $"Name;" +
                     $"ModelName;" +

--- a/MapBuddy/PartInfo/InfoPlayer.cs
+++ b/MapBuddy/PartInfo/InfoPlayer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.Info
 {
@@ -18,7 +19,7 @@ namespace MapBuddy.Info
 
         public InfoPlayer(string path, Dictionary<string, string> mapDict, bool splitByMap)
         {
-            output_dir = logger.GetLogDir() + "\\Part\\Player\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Part", "Player");
 
             header = $"Name;" +
                     $"ModelName;" +

--- a/MapBuddy/RegionInfo/InfoAutoDrawGroupPoint.cs
+++ b/MapBuddy/RegionInfo/InfoAutoDrawGroupPoint.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoBuddySummonPoint.cs
+++ b/MapBuddy/RegionInfo/InfoBuddySummonPoint.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoConnection.cs
+++ b/MapBuddy/RegionInfo/InfoConnection.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoDummy.cs
+++ b/MapBuddy/RegionInfo/InfoDummy.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoEnvironmentMapEffectBox.cs
+++ b/MapBuddy/RegionInfo/InfoEnvironmentMapEffectBox.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoEnvironmentMapOutput.cs
+++ b/MapBuddy/RegionInfo/InfoEnvironmentMapOutput.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoEnvironmentMapPoint.cs
+++ b/MapBuddy/RegionInfo/InfoEnvironmentMapPoint.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoFallPreventionRemoval.cs
+++ b/MapBuddy/RegionInfo/InfoFallPreventionRemoval.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoFastTravelRestriction.cs
+++ b/MapBuddy/RegionInfo/InfoFastTravelRestriction.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoGroupDefeatReward.cs
+++ b/MapBuddy/RegionInfo/InfoGroupDefeatReward.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoHitset.cs
+++ b/MapBuddy/RegionInfo/InfoHitset.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoHorseProhibition.cs
+++ b/MapBuddy/RegionInfo/InfoHorseProhibition.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoInvasionPoint.cs
+++ b/MapBuddy/RegionInfo/InfoInvasionPoint.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoMapNameOverride.cs
+++ b/MapBuddy/RegionInfo/InfoMapNameOverride.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoMapPoint.cs
+++ b/MapBuddy/RegionInfo/InfoMapPoint.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoMapPointDiscoveryOverride.cs
+++ b/MapBuddy/RegionInfo/InfoMapPointDiscoveryOverride.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoMapPointParticipationOverride.cs
+++ b/MapBuddy/RegionInfo/InfoMapPointParticipationOverride.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoMessage.cs
+++ b/MapBuddy/RegionInfo/InfoMessage.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoMountJump.cs
+++ b/MapBuddy/RegionInfo/InfoMountJump.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoMountJumpFall.cs
+++ b/MapBuddy/RegionInfo/InfoMountJumpFall.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoMufflingBox.cs
+++ b/MapBuddy/RegionInfo/InfoMufflingBox.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoMufflingPlane.cs
+++ b/MapBuddy/RegionInfo/InfoMufflingPlane.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoMufflingPortal.cs
+++ b/MapBuddy/RegionInfo/InfoMufflingPortal.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoNavmeshCutting.cs
+++ b/MapBuddy/RegionInfo/InfoNavmeshCutting.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoOther.cs
+++ b/MapBuddy/RegionInfo/InfoOther.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoPatrolRoute.cs
+++ b/MapBuddy/RegionInfo/InfoPatrolRoute.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoPatrolRoute22.cs
+++ b/MapBuddy/RegionInfo/InfoPatrolRoute22.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoPlayArea.cs
+++ b/MapBuddy/RegionInfo/InfoPlayArea.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoSFX.cs
+++ b/MapBuddy/RegionInfo/InfoSFX.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoSound.cs
+++ b/MapBuddy/RegionInfo/InfoSound.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoSoundRegion.cs
+++ b/MapBuddy/RegionInfo/InfoSoundRegion.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoSpawnPoint.cs
+++ b/MapBuddy/RegionInfo/InfoSpawnPoint.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoWeatherCreateAssetPoint.cs
+++ b/MapBuddy/RegionInfo/InfoWeatherCreateAssetPoint.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoWeatherOverride.cs
+++ b/MapBuddy/RegionInfo/InfoWeatherOverride.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoWindArea.cs
+++ b/MapBuddy/RegionInfo/InfoWindArea.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/RegionInfo/InfoWindSFX.cs
+++ b/MapBuddy/RegionInfo/InfoWindSFX.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace MapBuddy.RegionInfo
 {
@@ -21,7 +22,7 @@ namespace MapBuddy.RegionInfo
         {
             combined_file_name = $"Global_{propertyName}";
 
-            output_dir = logger.GetLogDir() + $"\\Region\\{propertyName}\\";
+            output_dir = Path.Combine(logger.GetLogDir(), "Region", propertyName);
 
             header = $"Name;" +
                     $"Shape;" +

--- a/MapBuddy/Util.cs
+++ b/MapBuddy/Util.cs
@@ -17,12 +17,12 @@ namespace MapBuddy
 
             if (map_selection == "All")
             {
-                map_list = Directory.GetFileSystemEntries(path + "\\map\\mapstudio", @"*.msb.dcx").ToList();
+                map_list = Directory.GetFileSystemEntries(Path.Combine(path, "map", "mapstudio"), @"*.msb.dcx").ToList();
                 logger.AddToLog($"Editing all maps.");
             }
             else
             {
-                List<string> temp = Directory.GetFileSystemEntries(path + "\\map\\mapstudio", @"*.msb.dcx").ToList();
+                List<string> temp = Directory.GetFileSystemEntries(Path.Combine(path, "map", "mapstudio"), @"*.msb.dcx").ToList();
                 foreach (string s in temp)
                 {
                     if (s.Contains(map_selection))


### PR DESCRIPTION
Changed the following things

- Replaced static path that was causing issues for users with a system that saves your last selected mod folder.
- Replaced all paths that were concatenated strings to use Path.Combine() for added support to users with alternative path formats.